### PR TITLE
Downgraded node checkout and setup actions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3  # Downgraded to v3
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3  # Downgraded to v3
         with:
           node-version: 14.17.5
 


### PR DESCRIPTION
Downgraded node checkout and setup actions tfrom v4 -> v3 due to compatibility issues